### PR TITLE
Fixes to allow complilation using gcc 4.7

### DIFF
--- a/templates/Array.cc
+++ b/templates/Array.cc
@@ -24,6 +24,7 @@ $State: Exp $
 #include <iostream>		// (bert) changed from iostream.h
 #include <math.h>
 //#include <string>		// (bert) changed from string.h
+#include <cstring>
 using namespace std;		// (bert) added
 
 /******************

--- a/templates/CachedArray.cc
+++ b/templates/CachedArray.cc
@@ -866,7 +866,7 @@ CachedArray<Type>::_histMedian(unsigned nBelow, unsigned nAbove)
   }
 
   Type floor, ceil;
-  extrema(&floor, &ceil);
+  this->extrema(&floor, &ceil);
 
   if (this->_debug)
       cout << "Floor and Ceiling: " << floor << " : " << ceil << endl;
@@ -893,7 +893,7 @@ CachedArray<Type>::_histMedian(unsigned nBelow, unsigned nAbove)
       cout << "(" << bin << " : " << hist[bin] << " : " << histMedian << ") " << flush;
 
   unsigned nBelow2, nAbove2;
-  removeAllNotIn(Type(hist.binStart(bin)), Type(hist.binStart(bin + 1)), 
+  this->removeAllNotIn(Type(hist.binStart(bin)), Type(hist.binStart(bin + 1)), 
 		 &nBelow2, &nAbove2);
 
   if (this->_debug)

--- a/templates/SimpleArray.cc
+++ b/templates/SimpleArray.cc
@@ -503,7 +503,7 @@ SimpleArray<Type>::removeAll(Type value)
     Type el = this->getElConst(i);
     if (el != value) {
       if (i != j)
-	setEl(j, el);
+	this->setEl(j, el);
       j++;
     }
   }
@@ -532,7 +532,7 @@ SimpleArray<Type>::removeAllIn(Type floor, Type ceil, unsigned *N)
       n++;
     else {
       if (i != j)
-	setEl(j, value);
+	this->setEl(j, value);
       j++;
     }
   }
@@ -566,7 +566,7 @@ SimpleArray<Type>::removeAllNotIn(Type floor, Type ceil,
       aboveCtr++;
     else {
       if (i != j)
-        setEl(j, value);
+        this->setEl(j, value);
       j++;
     }
   }
@@ -633,7 +633,7 @@ SimpleArray<Type>::prune()
     double value = double(this->getElConst(i));
     if (FINITE(value)) {
       if (i != j)
-	setEl(j, Type(value));
+	this->setEl(j, Type(value));
       j++;
     }
   }
@@ -650,7 +650,7 @@ SimpleArray<Type>::randuniform(double min, double max)
   double range = max - min;
 
   for (unsigned i = 0; i < this->_size; i++)
-    setEl(i, Type(drand48() * range + min));
+    this->setEl(i, Type(drand48() * range + min));
   
   return *this;
 }
@@ -660,7 +660,7 @@ SimpleArray<Type>&
 SimpleArray<Type>::randnormal(double mean, double std)
 {
   for (unsigned i = 0; i < this->_size; i++)
-    setEl(i, Type(gauss(mean, std)));
+    this->setEl(i, Type(gauss(mean, std)));
 
   return *this;
 }
@@ -996,7 +996,7 @@ SimpleArray<Type>::ceil(Type ceil)
   this->resetIterator();
   for (register unsigned i = 0; i < this->_size; i++)
     if ((*this)++ > ceil)
-      setEl(i, ceil);
+      this->setEl(i, ceil);
 }
 
 template <class Type>
@@ -1006,7 +1006,7 @@ SimpleArray<Type>::floor(Type floor)
   this->resetIterator();
   for (register unsigned i = 0; i < this->_size; i++)
     if ((*this)++ < floor)
-      setEl(i, floor);
+      this->setEl(i, floor);
 }
 
 //


### PR DESCRIPTION
Changes to fix problems with template compilation due to unqualified lookups of functions in the base template (adding this-> in a number of places). Also added <cstring> as a dependency of Array.cc to fix missing memcpy.
